### PR TITLE
Fixed variable mismatch issue in Post audio url docs 

### DIFF
--- a/async-api/overview/audio/post-audio-url.md
+++ b/async-api/overview/audio/post-audio-url.md
@@ -167,7 +167,7 @@ const responses = {
 
 request.post(audioOption, (error, response, body) => {
   const statusCode = response.statusCode;
-  if (err || Object.keys(responses).indexOf(statusCode.toString()) !== -1) {
+  if (error || Object.keys(responses).indexOf(statusCode.toString()) !== -1) {
     throw new Error(responses[statusCode]);
   }
   console.log('Status code: ', statusCode);


### PR DESCRIPTION
## Type of Pull Request 
- [ ] 📖 Documentation Update

## Description
>In NodeJS post Audio Url docs for async-api the variable passed as the parameter in the callback function (error) is not the same as the once used in the function (err).


