### PR TITLE
Reformat summary example

### DIFF
--- a/docs/conversation-api/concepts/summarization.md
+++ b/docs/conversation-api/concepts/summarization.md
@@ -32,7 +32,84 @@ Real-time Summaries are not currently supported.
 
 The following sample is a multi-line transcript and its corresponding Summary created by the Summary API:
 
-![Recorded Transcript and Summary created by the API](/img/summary_labs_final.png)
+<table>
+    <col />
+    <col />
+    <thead>
+        <tr>
+            <th>
+                Recorded Transcript
+            </th>
+            <th>
+                Summary Created by Summary API
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <p>
+                    <em>Sunita:</em> You're breaking up a lot.
+                </p>
+                <p>
+                    <em>Liam:</em> Yeah, I know at least hopefully you guys can
+                    see the transcription that's going on with what I am saying.
+                </p>
+                <p>
+                    <em>Liam:</em> But yeah, we totally need to shift our focus
+                    more into our Dev, you know, in the field of Advocates who
+                    can really help us grow within their own circles.
+                </p>
+                <p>
+                    <em>Sunita:</em> Yeah.
+                </p>
+                <p>
+                    <em>Liam:</em> So I will go ahead and I will set up a
+                    discussion with the product.
+                </p>
+                <p>
+                    <em>Liam:</em> And the dev team.
+                </p>
+                <p>
+                    <em>Sunita:</em> Okay, that works.
+                </p>
+                <p>
+                    <em>Sunita:</em> Perfect.
+                </p>
+                <p>
+                    <em>Sunita:</em> What else Anh I know you had a couple of
+                    other things on the agenda, so we can totally talk about
+                    that right now.
+                </p>
+                <p>
+                    <em>Anh:</em> Okay.
+                </p>
+                <p>
+                    <em>Anh:</em> Yeah, so the only other thing was as we're
+                    talking about employee growth I wanted to basically touch
+                    base with you and understand how we can or in which
+                    geographies we need to focus on the sales hires first
+                    because what and what would be the most important would it
+                    be industry or would it be unreasonable understanding
+                    because for example in a region like Europe there is there
+                    are multiple languages and Regional influences.
+                </p>
+                <p>
+                    <em>Anh:</em> No influences, so should we focus on that or
+                    focus more on the industry and grow that way, so they're
+                    both strategies?
+                </p>
+            </td>
+            <td>
+                <p>
+                    Sunita, Liam, and Anh need to focus more on the Dev team and
+                    on the product. In order to focus on the sales hire, Anh
+                    needs to know which geographies they should focus on.
+                </p>
+            </td>
+        </tr>
+    </tbody>
+</table>
 
 You can enable the Summary API for Async APIs by setting the parameter `enableSummary=true` when processing a conversation via Async API </docs/async-api/introduction/>.
 

--- a/docs/conversation-api/concepts/summarization.md
+++ b/docs/conversation-api/concepts/summarization.md
@@ -33,8 +33,6 @@ Real-time Summaries are not currently supported.
 The following sample is a multi-line transcript and its corresponding Summary created by the Summary API:
 
 <table>
-    <col />
-    <col />
     <thead>
         <tr>
             <th>


### PR DESCRIPTION
Refactors the image example of the Summary API into an HTML table.

## Type of Pull Request 
> Check all applicable

- [ ] 🎉 Feature Enhancement
- [ ] 🐛 Bug Fix
- [X] 📖 Documentation Update
- [ ] ❇️ Other

## Description
> Removed the markdown reference to the Summary API example image and replaced it with an HTML table. I opted for HTML due to length of the text. Tested in ReadMe, too, and will migrate fine.

## Issue
> https://rammerai.atlassian.net/browse/DC-435


